### PR TITLE
Feature/fe-014 - Typography 컴포넌트

### DIFF
--- a/src/app/post/components/Post/Post.test.tsx
+++ b/src/app/post/components/Post/Post.test.tsx
@@ -1,12 +1,12 @@
 import { render, screen } from '@/tests/test-utils';
-import { Post } from '@/components';
+import PostClientComponent from './Post';
 import PostServerComponent from './Post.server';
 
 // 컴포넌트 테스트 예시 코드 2
 
 describe('Test Post components', () => {
 	test('Post component can render multiple posts', async () => {
-		render(<Post />);
+		render(<PostClientComponent />);
 
 		const listItems = await screen.findAllByText(/post title/i);
 

--- a/src/components/Typography/Typography.css.ts
+++ b/src/components/Typography/Typography.css.ts
@@ -1,0 +1,12 @@
+import { recipe, RecipeVariants } from '@vanilla-extract/recipes';
+
+import { fontVariant, colorVariant } from '@/styles/variant.css';
+
+export const typoVariant = recipe({
+	variants: {
+		color: colorVariant,
+		variant: fontVariant,
+	},
+});
+
+export type TypoVariant = RecipeVariants<typeof typoVariant>;

--- a/src/components/Typography/Typography.test.css.ts
+++ b/src/components/Typography/Typography.test.css.ts
@@ -1,0 +1,6 @@
+import { style } from '@vanilla-extract/css';
+
+// test 코드에서 사용하기 위한 css
+export const fontWeight100 = style({
+	fontWeight: 100,
+});

--- a/src/components/Typography/Typography.test.tsx
+++ b/src/components/Typography/Typography.test.tsx
@@ -1,0 +1,41 @@
+import { screen, render } from '@/tests/test-utils';
+import Typography from './Typography';
+import { createRef } from 'react';
+import { fontWeight100 } from './Typography.test.css';
+
+describe('Typography tests', () => {
+	test('as 속성에 맞는 HTML 태그와 children을 렌더링 한다', () => {
+		const headingText = 'children text';
+		render(
+			<>
+				<Typography variant="display1" as="h1">
+					{headingText}
+				</Typography>
+			</>,
+		);
+		const heading1 = screen.getByRole('heading', { level: 1 });
+		expect(heading1).toBeInTheDocument();
+		expect(heading1).toHaveTextContent(headingText);
+	});
+
+	test('ref를 전달할 수 있다', () => {
+		const ref = createRef<HTMLElement>();
+		render(
+			<Typography variant="display1" as="h1" ref={ref}>
+				display1
+			</Typography>,
+		);
+		const $target = screen.getByRole('heading', { level: 1 });
+		expect(ref.current).toBe($target);
+	});
+
+	test('className을 넘겨 스타일을 변경할 수 있다', () => {
+		render(
+			<Typography variant="display1" as="h1" className={fontWeight100}>
+				fontWeight100
+			</Typography>,
+		);
+		const $target = screen.getByRole('heading', { level: 1 });
+		expect($target).toHaveStyle({ fontWeight: '100' });
+	});
+});

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import clsx from 'classnames';
+import { type TypoVariant, typoVariant } from './Typography.css';
+
+type Props = React.HTMLAttributes<HTMLElement> & {
+	as?: 'code' | 'div' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'label' | 'p' | 'span';
+	children: React.ReactNode;
+	className?: string;
+} & TypoVariant;
+
+const Typography = React.forwardRef<HTMLElement, Props>(
+	({ as = 'div', variant = 'body2', color = 'primary', className = '', children, ...rest }, ref) => {
+		return React.createElement(
+			as,
+			{
+				className: clsx(typoVariant({ variant, color }), className),
+				ref,
+				...rest,
+			},
+			children,
+		);
+	},
+);
+
+Typography.displayName = 'Typography';
+
+export default Typography;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export { default as Badge } from './Badge/Badge';
-export { default as Post } from '../app/post/components/Post/Post';
+
+export { default as Typography } from './Typography/Typography';

--- a/src/styles/variant.css.ts
+++ b/src/styles/variant.css.ts
@@ -97,6 +97,7 @@ export const fontVariant = {
 	},
 	label2: {
 		fontSize: fontSize['md'],
+		fontWeight: fontWeight['semibold'],
 		lineHeight: lineHeights['sm'],
 	},
 	label3: {

--- a/src/styles/variant.css.ts
+++ b/src/styles/variant.css.ts
@@ -1,0 +1,130 @@
+import { themeTokens } from './theme.css';
+import { typedEntries } from '@/utils/typedEntries';
+
+const { fontSize, fontWeight, lineHeights, color } = themeTokens;
+
+// fontsize, fontweight, lineheight 관련 css 속성
+export const fontVariant = {
+	display1: {
+		fontSize: fontSize['9xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['7xl'],
+	},
+	display2: {
+		fontSize: fontSize['8xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['6xl'],
+	},
+	display3: {
+		fontSize: fontSize['7xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['5xl'],
+	},
+	display4: {
+		fontSize: fontSize['6xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['4xl'],
+	},
+	heading1: {
+		fontSize: fontSize['5xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['3xl'],
+	},
+	heading2: {
+		fontSize: fontSize['4xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['2xl'],
+	},
+	heading3: {
+		fontSize: fontSize['3xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['xl'],
+	},
+	heading4: {
+		fontSize: fontSize['2xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['lg'],
+	},
+	title1: {
+		fontSize: fontSize['xl'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['lg'],
+	},
+	title2: {
+		fontSize: fontSize['lg'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['md'],
+	},
+	title3: {
+		fontSize: fontSize['md'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['sm'],
+	},
+	title4: {
+		fontSize: fontSize['sm'],
+		fontWeight: fontWeight['bold'],
+		lineHeight: lineHeights['xs'],
+	},
+	body1: {
+		fontSize: fontSize['lg'],
+		fontWeight: fontWeight['regular'],
+		lineHeight: lineHeights['lg'],
+	},
+	body2: {
+		fontSize: fontSize['md'],
+		fontWeight: fontWeight['regular'],
+		lineHeight: lineHeights['md'],
+	},
+	body3: {
+		fontSize: fontSize['sm'],
+		fontWeight: fontWeight['regular'],
+		lineHeight: lineHeights['sm'],
+	},
+	body4: {
+		fontSize: fontSize['xs'],
+		fontWeight: fontWeight['regular'],
+		lineHeight: lineHeights['xs'],
+	},
+	body5: {
+		fontSize: fontSize['2xs'],
+		fontWeight: fontWeight['regular'],
+		lineHeight: lineHeights['2xs'],
+	},
+	label1: {
+		fontSize: fontSize['lg'],
+		fontWeight: fontWeight['semibold'],
+		lineHeight: lineHeights['md'],
+	},
+	label2: {
+		fontSize: fontSize['md'],
+		lineHeight: lineHeights['sm'],
+	},
+	label3: {
+		fontSize: fontSize['sm'],
+		fontWeight: fontWeight['semibold'],
+		lineHeight: lineHeights['xs'],
+	},
+	label4: {
+		fontSize: fontSize['xs'],
+		fontWeight: fontWeight['semibold'],
+		lineHeight: lineHeights['2xs'],
+	},
+	label5: {
+		fontSize: fontSize['2xs'],
+		fontWeight: fontWeight['semibold'],
+		lineHeight: lineHeights['3xs'],
+	},
+	label6: {
+		fontSize: fontSize['3xs'],
+		fontWeight: fontWeight['semibold'],
+		lineHeight: lineHeights['4xs'],
+	},
+};
+
+// textcolor 관련 css 속성
+export const colorVariant = typedEntries(color).reduce(
+	(acc, [k, v]) => ({ ...acc, [k]: { color: v } }),
+	{} as {
+		[Property in keyof typeof color]: { color: string };
+	},
+);

--- a/src/utils/typedEntries.ts
+++ b/src/utils/typedEntries.ts
@@ -1,0 +1,2 @@
+// Object.entries(...) 와 동일하되 타이핑만 적용된 함수
+export const typedEntries = Object.entries as <T>(obj: T) => Array<[keyof T, T[keyof T]]>;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import * as path from 'path';
+import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+
+// https://vitejs.dev/config/
+export default defineConfig({
+	plugins: [react(), vanillaExtractPlugin()],
+	resolve: {
+		alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
+	},
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,17 +1,14 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
-import * as path from 'path';
-import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import viteConfig from './vite.config';
 
 // https://vitejs.dev/config/
-export default defineConfig({
-	plugins: [react(), vanillaExtractPlugin()],
-	test: {
-		globals: true,
-		environment: 'jsdom',
-		setupFiles: ['./src/tests/setupTests.ts'],
-	},
-	resolve: {
-		alias: [{ find: '@', replacement: path.resolve(__dirname, 'src') }],
-	},
-});
+export default mergeConfig(
+	viteConfig,
+	defineConfig({
+		test: {
+			globals: true,
+			environment: 'jsdom',
+			setupFiles: ['./src/tests/setupTests.ts'],
+		},
+	}),
+);


### PR DESCRIPTION
#15 

## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- [x] Typography 생성 및 테스트 코드 생성
- [x] vitest config 상의 타입 에러를 해결하기 위해 vite.confg와 vitest.config 분리

## 문제 상황과 해결

- `colorToken` 을 아래와 같은 `colorVariant` 형태로 변환하는 작업을 위해 `typedEntries` + `Array.reduce` 함수를 사용해 변환

```tsx
const colorToken: {
    primary50: string,
    primary100: string,
    primary200: string,
}



const colorVariant: {
    primary50: {
        color: string
    },
    primary100: {
        color: string
    },
    primary200: {
        color: string
    },
}
```



## 비고

- [Mapped Type](https://www.typescriptlang.org/docs/handbook/2/mapped-types.html)