### PR TITLE
feature/FE-044: MapConfirmButton disabled 처리

### DIFF
--- a/src/components/Map/MapConfirmButton.tsx
+++ b/src/components/Map/MapConfirmButton.tsx
@@ -12,7 +12,7 @@ const MapConfirmButton = ({ onClick }: MapConfirmButtonProps) => {
   const { selectedPlace, keyword } = useMapContext();
   return (
     <div className={buttonWrapper}>
-      <Button disabled={!Boolean(keyword)} size="medium" aria-label="확인" onClick={() => onClick(selectedPlace)}>
+      <Button disabled={!keyword} size="medium" aria-label="확인" onClick={() => onClick(selectedPlace)}>
         확인
       </Button>
     </div>

--- a/src/components/Map/MapConfirmButton.tsx
+++ b/src/components/Map/MapConfirmButton.tsx
@@ -9,10 +9,10 @@ type MapConfirmButtonProps = {
 };
 
 const MapConfirmButton = ({ onClick }: MapConfirmButtonProps) => {
-  const { selectedPlace } = useMapContext();
+  const { selectedPlace, keyword } = useMapContext();
   return (
     <div className={buttonWrapper}>
-      <Button size="medium" aria-label="확인" onClick={() => onClick(selectedPlace)}>
+      <Button disabled={!Boolean(keyword)} size="medium" aria-label="확인" onClick={() => onClick(selectedPlace)}>
         확인
       </Button>
     </div>


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- [x] 검색어를 입력하지 않는 상황에 대해서 MapConfirmButton disabled 처리

## 문제 상황과 해결

https://www.notion.so/yapp-workspace/undefined-undefined-512edfc77351471ba88f63567377a88c?pvs=4

- 검색어를 입력하지 않은 경우, kakao map API 호출이 일어나지 않아 context value에 등록된 기본값이 위치에 저장되는 현상이 있었습니다.
- ux상, 검색어 입력 없는 케이스는 저장이 아닌 검색을 유도해야 하기 때문에 button을 disabled 처리했습니다.
 