### PR TITLE
feature/FE-052 :  IconButton disabled 에러 수정

### DIFF
--- a/public/sprite.svg
+++ b/public/sprite.svg
@@ -38,6 +38,10 @@
 <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1072_16008" result="shape"/>
 </filter>
 
+<clipPath id="clip0_239_7075">
+<rect width="36" height="36" fill="white"/>
+</clipPath>
+
 <clipPath id="clip0_239_7080">
 <rect width="36" height="36" fill="white"/>
 </clipPath>
@@ -166,10 +170,14 @@
 <path d="M12 18H24" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
 </g>
 </symbol><symbol id="minus-hover" viewBox="0 0 36 36">
+<g clip-path="url(#clip0_239_7075)">
 <circle cx="18" cy="18" r="12" fill="#1C1A42" fill-opacity="0.08"/>
 <path d="M4.5 18C4.5 25.4558 10.5442 31.5 18 31.5C25.4558 31.5 31.5 25.4558 31.5 18C31.5 10.5442 25.4558 4.5 18 4.5C10.5442 4.5 4.5 10.5442 4.5 18Z" fill="#5568F9"/>
 <path d="M12 18H24M18 31.5C10.5442 31.5 4.5 25.4558 4.5 18C4.5 10.5442 10.5442 4.5 18 4.5C25.4558 4.5 31.5 10.5442 31.5 18C31.5 25.4558 25.4558 31.5 18 31.5Z" stroke="#5568F9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M12 18H24" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="18" cy="18" r="18" fill="#1C1A42" fill-opacity="0.04"/>
+</g>
+
 </symbol><symbol id="minus" viewBox="0 0 36 36">
 <path d="M4.5 18C4.5 25.4558 10.5442 31.5 18 31.5C25.4558 31.5 31.5 25.4558 31.5 18C31.5 10.5442 25.4558 4.5 18 4.5C10.5442 4.5 4.5 10.5442 4.5 18Z" fill="#5568F9"/>
 <path d="M12 18H24M18 31.5C10.5442 31.5 4.5 25.4558 4.5 18C4.5 10.5442 10.5442 4.5 18 4.5C25.4558 4.5 31.5 10.5442 31.5 18C31.5 25.4558 25.4558 31.5 18 31.5Z" stroke="#5568F9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>

--- a/public/spriteIcons/minus-hover.svg
+++ b/public/spriteIcons/minus-hover.svg
@@ -1,6 +1,14 @@
 <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_239_7075)">
 <circle cx="18" cy="18" r="12" fill="#1C1A42" fill-opacity="0.08"/>
 <path d="M4.5 18C4.5 25.4558 10.5442 31.5 18 31.5C25.4558 31.5 31.5 25.4558 31.5 18C31.5 10.5442 25.4558 4.5 18 4.5C10.5442 4.5 4.5 10.5442 4.5 18Z" fill="#5568F9"/>
 <path d="M12 18H24M18 31.5C10.5442 31.5 4.5 25.4558 4.5 18C4.5 10.5442 10.5442 4.5 18 4.5C25.4558 4.5 31.5 10.5442 31.5 18C31.5 25.4558 25.4558 31.5 18 31.5Z" stroke="#5568F9" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 <path d="M12 18H24" stroke="white" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+<circle cx="18" cy="18" r="18" fill="#1C1A42" fill-opacity="0.04"/>
+</g>
+<defs>
+<clipPath id="clip0_239_7075">
+<rect width="36" height="36" fill="white"/>
+</clipPath>
+</defs>
 </svg>

--- a/src/app/write/components/Counter/Counter.tsx
+++ b/src/app/write/components/Counter/Counter.tsx
@@ -23,9 +23,9 @@ const Counter = ({ control, name, min = 2, max = 20, ...rest }: CounterProps<any
         name={name}
         render={({ field: { value, onChange } }) => (
           <>
-            <IconButton type="button" iconType="minus" onClick={handleClickSubtract} disabled={value <= 2} />
+            <IconButton type="button" iconType="minus" onClick={handleClickSubtract} disabled={value <= 2} hover />
             <input type="number" min={min} max={max} value={value} onChange={onChange} />
-            <IconButton type="button" iconType="plus" onClick={handleClickAdd} />
+            <IconButton type="button" iconType="plus" onClick={handleClickAdd} hover />
           </>
         )}
       />

--- a/src/app/write/components/Form/FirstStep.tsx
+++ b/src/app/write/components/Form/FirstStep.tsx
@@ -19,6 +19,7 @@ const FirstStep = ({ nextStep }: stepProps) => {
   const { stepOne, setData } = useFormStore();
 
   const method = useForm<StepOneSchema>({
+    mode: 'onSubmit',
     resolver: zodResolver(stepOneSchema),
     defaultValues: stepOne || {},
   });

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -42,8 +42,12 @@ const IconButton = ({
 
   useEffect(() => {
     if (!error) return;
-    setStatus(error ? ICON_STATUS.ERROR : disabled ? ICON_STATUS.DISABLE : ICON_STATUS.DEFAULT);
+    setStatus(error ? ICON_STATUS.ERROR : ICON_STATUS.DEFAULT);
   }, [error, disabled]);
+
+  useEffect(() => {
+    setStatus(disabled ? ICON_STATUS.DISABLE : ICON_STATUS.DEFAULT);
+  }, [disabled]);
 
   const handleMouseEnter = () => {
     if (error || disabled || status === ICON_STATUS.ACTIVE) return;

--- a/src/components/SvgIcon/SvgIcon.tsx
+++ b/src/components/SvgIcon/SvgIcon.tsx
@@ -1,16 +1,16 @@
 import { SVGProps } from 'react';
 
 interface Props extends SVGProps<SVGSVGElement> {
-	/** icon id (spriteIcons 폴더하에 있는 svg 파일명과 동일함) */
-	id: string;
+  /** icon id (spriteIcons 폴더하에 있는 svg 파일명과 동일함) */
+  id: string;
 }
 
 const SvgIcon = ({ id, width = 16, height = 16, fill = 'none', ...rest }: Props) => {
-	return (
-		<svg width={width} height={height} fill={fill} {...rest}>
-			<use href={`/sprite.svg#${id}`} />
-		</svg>
-	);
+  return (
+    <svg width={width} height={height} fill={fill} {...rest}>
+      <use href={`/sprite.svg#${id}`} />
+    </svg>
+  );
 };
 
 export default SvgIcon;


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- IconButton useEffect 관련으로 disabled가 미적용되는 문제 해결

## 문제 상황과 해결
- disabled 상태를 캐치해주지 못해 2개의 useEffect로 분리했습니다.  

이전 코드
```typescript
  useEffect(() => {
    if (!error) return;
    setStatus(error ? ICON_STATUS.ERROR : disabled ? ICON_STATUS.DISABLE : ICON_STATUS.DEFAULT);
  }, [error, disabled]);
```
변경된 코드
```typescript
  useEffect(() => {
    if (!error) return;
    setStatus(error ? ICON_STATUS.ERROR : ICON_STATUS.DEFAULT);
  }, [error, disabled]);

  useEffect(() => {
  // disabled의 경우, return문이 존재하면 default로 상태 복원이 되지않아 return문을 사용하지 않았습니다.
    setStatus(disabled ? ICON_STATUS.DISABLE : ICON_STATUS.DEFAULT);
  }, [disabled]);

```

- 다만 '-' 버튼 hover시 svg와 id가 제대로 변경되고 있음에도 hover 아이콘이 렌더링되지 않는것으로 보입니다

https://github.com/YAPP-Github/mukpat-client/assets/51940808/6a502db9-f539-4241-bdce-01c424a95ede



## 비고

- [notion QA](https://www.notion.so/yapp-workspace/625acacffe134013925bf033cded9bf7?pvs=4)
