### PR TITLE
Feature/FE-050 : BottomSheet 컴포넌트 추가

### DIFF
--- a/src/components/BottomSheet/BottomSheet.css.ts
+++ b/src/components/BottomSheet/BottomSheet.css.ts
@@ -1,0 +1,72 @@
+import { themeTokens } from '@/styles/theme.css';
+import { style, globalStyle } from '@vanilla-extract/css';
+import { fontVariant } from '@/styles/variant.css';
+import { recipe } from '@vanilla-extract/recipes';
+const { color, zIndices } = themeTokens;
+
+export const titleWrapper = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '30px',
+});
+globalStyle(`${titleWrapper} > div`, {
+  ...fontVariant.title3,
+  color: color.secondary,
+});
+globalStyle(`${titleWrapper} > button`, {
+  marginRight: '-4px',
+});
+export const background = recipe({
+  base: {
+    position: 'fixed',
+    width: '100%',
+    height: '100%',
+    top: '0',
+    left: '0',
+    bottom: '0',
+    background: color.black,
+    opacity: '0.3',
+    zIndex: zIndices.overlay,
+  },
+  variants: {
+    open: {
+      true: {},
+      false: {
+        display: 'none',
+      },
+    },
+  },
+  defaultVariants: {
+    open: false,
+  },
+});
+export const wrap = recipe({
+  base: {
+    position: 'fixed',
+    display: 'flex',
+    bottom: '0',
+    width: '100%',
+    background: color.white,
+    zIndex: zIndices.modal,
+    padding: '20px',
+    borderRadius: '14px 14px 0px 0px',
+    flexDirection: 'column',
+    justifyContent: 'flex-end',
+  },
+  variants: {
+    open: {
+      true: {
+        transform: 'translate3d(0, 0, 0)',
+        transition: 'all 300ms',
+      },
+      false: {
+        transform: 'translate3d(0, 100%, 0)',
+        transition: 'all 300ms',
+      },
+    },
+  },
+  defaultVariants: {
+    open: false,
+  },
+});

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { HTMLAttributes } from 'react';
+import cx from 'classnames';
+import { titleWrapper, background, wrap } from './BottomSheet.css';
+import IconButton from '../IconButton/IconButton';
+import { useLockScroll } from '@/hooks';
+import { useModalControl } from './hooks';
+
+type BottomSheetProps = {
+  onClose: () => void;
+  title?: string;
+} & HTMLAttributes<HTMLDivElement>;
+
+const BottomSheet = ({ className, onClose, title, children, ...rest }: BottomSheetProps) => {
+  useLockScroll();
+  const { ref, isOpen, closeModalWithTransition } = useModalControl({ onClose });
+
+  return (
+    <>
+      <div className={cx(background({ open: isOpen }))} data-testid="outside"></div>
+      <div className={cx(wrap({ open: isOpen }), className)} {...rest} ref={ref}>
+        <div className={titleWrapper}>
+          <div>{title}</div>
+          <IconButton iconType="close" width={36} height={36} onClick={closeModalWithTransition}></IconButton>
+        </div>
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default BottomSheet;

--- a/src/components/BottomSheet/README.md
+++ b/src/components/BottomSheet/README.md
@@ -1,0 +1,27 @@
+# BottomSheet
+
+## 사용 예시
+- useOverlay 훅을 사용해 bottomSheet을 띄울 수 있다.
+  - 버튼을 눌렀을때, 오버레이 형태로 띄우고 싶다면 아래와 같이 사용해야 한다.
+```tsx
+const Test = () => {
+	const [openBottomSheet, closeBottomSheet] = useOverlay();
+
+	const renderBottomSheet = () => {
+		return (
+			<BottomSheet onClose={closeBottomSheet} titie="타이틀 영역 입니다" >
+                <div>원하는 내용 적기</div>
+			</BottomSheet>
+		);
+	};
+	return (
+		<div>
+			<button onClick={() => openBottomSheet(renderBottomSheet())}>BottomSheet Button</button>
+		</div>
+	);
+};
+export default Test;
+```
+
+- background 클릭시 close 
+- x 버튼 클릭시 close 

--- a/src/components/BottomSheet/hooks/index.ts
+++ b/src/components/BottomSheet/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useModalControl } from './useModalControl/useModalControl';

--- a/src/components/BottomSheet/hooks/useModalControl/useModalControl.ts
+++ b/src/components/BottomSheet/hooks/useModalControl/useModalControl.ts
@@ -1,0 +1,41 @@
+import { useState, useEffect, useRef } from 'react';
+import { useClickOutside } from '@/hooks';
+
+interface Props {
+  onClose: () => void;
+}
+const useModalControl = ({ onClose }: Props) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const closeStatus = useRef(false);
+  const closeModalWithTransition = () => {
+    closeStatus.current = true;
+    setIsOpen(false);
+  };
+  const openModalWithTransition = () => {
+    setIsOpen(true);
+  };
+  const ref = useClickOutside<HTMLDivElement>({
+    onClickOutside: () => {
+      closeModalWithTransition();
+    },
+  });
+  const handleTransitionEnd = (event: TransitionEvent) => {
+    if (event.propertyName === 'transform' && closeStatus.current) {
+      onClose();
+    }
+  };
+  useEffect(() => {
+    openModalWithTransition();
+    const element = ref.current;
+    if (!element) return;
+    element.addEventListener('transitionend', handleTransitionEnd);
+    return () => {
+      element.removeEventListener('transitionend', handleTransitionEnd);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { ref, isOpen, closeModalWithTransition };
+};
+
+export default useModalControl;

--- a/src/components/Modal/Modal.css.ts
+++ b/src/components/Modal/Modal.css.ts
@@ -44,11 +44,11 @@ export const modalWrapper = recipe({
   },
 });
 export const backgroundWrapper = style({
+  position: 'fixed',
   width: '100%',
   height: '100%',
   top: '0',
   left: '0',
-  position: 'absolute',
   background: '#000000',
   opacity: '0.3',
   zIndex: zIndices.overlay,

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@
 import { HTMLAttributes } from 'react';
 import cx from 'classnames';
 import { type Size, modalWrapper, backgroundWrapper } from './Modal.css';
-import { useClickOutside } from '@/hooks';
+import { useClickOutside, useLockScroll } from '@/hooks';
 
 type ModalProps = {
   size?: Size;
@@ -11,12 +11,12 @@ type ModalProps = {
 } & HTMLAttributes<HTMLDivElement>;
 
 const Modal = ({ size, onClose, overflow, className, children, ...rest }: ModalProps) => {
+  useLockScroll();
   const ref = useClickOutside<HTMLDivElement>({
     onClickOutside: () => {
       onClose();
     },
   });
-
   return (
     <>
       <div className={cx(backgroundWrapper)} data-testid="outside"></div>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -33,3 +33,5 @@ export { default as Map } from './Map/Map';
 export { default as Loading } from './Loading/Loading';
 
 export { default as Skeleton } from './Skeleton/Skeleton';
+
+export { default as BottomSheet } from './BottomSheet/BottomSheet';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -11,3 +11,5 @@ export { default as useIntersectObserver } from './useIntersectObserver/useInter
 export { default as useOverlay } from './useOverlay/useOverlay';
 
 export { default as useClipBoard } from './useClipBoard/useClipBoard';
+
+export { default as useLockScroll } from './useLockScroll/useLockScroll';

--- a/src/hooks/useLockScroll/useLockScroll.ts
+++ b/src/hooks/useLockScroll/useLockScroll.ts
@@ -1,0 +1,12 @@
+import { useLayoutEffect } from 'react';
+
+const useLockScroll = () => {
+  useLayoutEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, []);
+};
+
+export default useLockScroll;


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- BottomSheet 컴포넌트 추가
- BottomSheet 열리고 닫힐때 애니메이션 적용 
- 오버레이 나올때 페이지 scroll lock 추가  (Modal, BottomSheet)
![bottomsheet](https://github.com/YAPP-Github/mukpat-client/assets/36434665/7ae6e89f-92f1-4211-873c-29a1a556a6c2)
- modal background 전체 적용

## 문제 상황과 해결

-  useOverlay 사용시 id=overlay-container 태그 안에 있던 컴포넌트가 추가, 삭제 로직과  BottomSheet에서 사용하는 css transition 으로 화면의 크기를 0으로 만드는 닫기 로직이 둘다 있으며, 0.3초동안 애니메이션이 실행 되어야 하기 때문에 transition이 끝난 이후에 useOverlay의 onClose 를 실행해야 했다. 
![overlay](https://github.com/YAPP-Github/mukpat-client/assets/36434665/d057a7df-fc33-4e10-92e9-21ac028c8218)


- transitionend 이벤트를 사용 하여 end 된 이후 onClose 실행 

순서
- css 로 모달 화면을 0으로 만드는 transition 실행 -> transition 끝난 이후 onClose를 실행하여 BottomSheet 컴포넌트 삭제

## 비고

-  https://developer.mozilla.org/en-US/docs/Web/API/Element/transitionend_event
