### PR TITLE
Feature/FE-074: useMediaQuary에서 state와 effect를 분리한 Hook 추가

### DIFF
--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -1,19 +1,14 @@
 'use client';
 import FirstStep from './components/Form/FirstStep';
 import SecondStep from './components/Form/SecondStep';
-import useFunnel from '@/hooks/useFunnel/useFunnel';
 import { Typography } from '@/components';
 import { wrapper } from './style.css';
-import { useEffect, useState } from 'react';
-import { useMediaQuery } from '@/hooks';
+import { useEffect } from 'react';
+import { useIsMobile, useFunnel } from '@/hooks';
 
 export default function Write() {
   const [step, { nextStep }] = useFunnel(['1', '2']);
-  const [isMobile, setMobile] = useState<boolean>(false);
-  const mobile = useMediaQuery({ bp: 'm' });
-  useEffect(() => {
-    setMobile(mobile);
-  }, [mobile]);
+  const mobile = useIsMobile();
 
   const preventClose = (e: BeforeUnloadEvent) => {
     e.preventDefault();
@@ -31,7 +26,7 @@ export default function Write() {
 
   return (
     <div className={wrapper}>
-      <Typography variant={isMobile ? 'title1' : 'heading1'} as="p" color="primary500">
+      <Typography variant={mobile ? 'title1' : 'heading1'} as="p" color="primary500">
         우리 회사 먹팟 만들기
       </Typography>
       {step === '1' && <FirstStep nextStep={nextStep} />}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -14,6 +14,10 @@ export { default as useClipBoard } from './useClipBoard/useClipBoard';
 
 export { default as useMediaQuery } from './useMediaQuery/useMediaQuery';
 
+export { default as useIsMobile } from './useIsMobile/useIsMobile';
+
 export { default as useLockScroll } from './useLockScroll/useLockScroll';
 
 export { default as useLoginRedirect } from './useLoginRedirect/useLoginRedirect';
+
+export { default as useFunnel } from './useFunnel/useFunnel';

--- a/src/hooks/useIsMobile/useIsMobile.ts
+++ b/src/hooks/useIsMobile/useIsMobile.ts
@@ -1,0 +1,13 @@
+import { useEffect, useState } from 'react';
+import useMediaQuery from '../useMediaQuery/useMediaQuery';
+
+const useIsMobile = () => {
+  const [isMobile, setMobile] = useState<boolean>(false);
+  const mobile = useMediaQuery({ bp: 'm' });
+  useEffect(() => {
+    setMobile(mobile);
+  }, [mobile]);
+  return isMobile;
+};
+
+export default useIsMobile;

--- a/src/styles/theme.css.ts
+++ b/src/styles/theme.css.ts
@@ -209,3 +209,5 @@ export const screenMQ = {
   /** mobile 대응 max-width: 791px*/
   m: `screen and (max-width: ${breakPoints.m}px)`,
 };
+
+export type BreakPoints = keyof typeof breakPoints;


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- Hydration Error를 해결하기 위해, useState와 useEffect를 사용했습니다.
- 코드 가독성을 위해, useMediaQuery와 함께 본문에 쓰이던 useState와 useEffect를 합쳐 하나의 useIsMobile 훅을 만들었습니다.  
- 디자인 시안에 맞춰 하나의 breakpoint에 대응하고 있습니다.

*as is*
```javascript
  const [isMobile, setMobile] = useState<boolean>(false);
  const mobile = useMediaQuery({ bp: 'm' });
  useEffect(() => {
    setMobile(mobile);
  }, [mobile]);
```
*to be*
```javascript
 const mobile = useIsMobile();
```

## 문제 상황

- Nextjs에서 pre-render된 DOM과 client에서 useMediaQuery에 의해 render된 결과물 사이의 차이로 Hydration에러가 발생했습니다.
- 해당 에러를 해결하기 위해, useState와 useEffect로 React트리와 DOM을 동기화했습니다.

## 비고

- [useMediaQuery Hydration Error issue](https://www.notion.so/yapp-workspace/useMediaQuery-Hydration-Error-issue-52ee050b454149bfbf36c0600a46e02c?pvs=4)
