### PR TITLE
feature/FE-088 : 로그인 유지 로직 추가

### DIFF
--- a/src/api/user/api.ts
+++ b/src/api/user/api.ts
@@ -22,6 +22,9 @@ class UserAPI {
   async postLogout() {
     return request.post('v1/users/logout').json();
   }
+  async postRefresh() {
+    return request.post('v1/users/refresh').json();
+  }
 }
 
 export const userAPI = new UserAPI();

--- a/src/utils/ky/hooks/processResponse.ts
+++ b/src/utils/ky/hooks/processResponse.ts
@@ -1,16 +1,18 @@
-import { AfterResponseHook } from 'ky';
+import ky, { AfterResponseHook } from 'ky';
 import { ResponseData } from '@/types/data';
-
+import { userAPI } from '@/api/user/api';
 /** response 에서 필요한 데이터 추출 및 에러 전처리 */
 const processResponse: AfterResponseHook = async (request, options, response) => {
-	if (response.status === 204) {
-		return new Response(undefined, { status: 204 });
-	}
-
-	const data: ResponseData = await response?.json();
-	return new Response(JSON.stringify(data?.result ?? data?.message), {
-		status: response.status,
-	});
+  if (response.status === 204) {
+    return new Response(undefined, { status: 204 });
+  } else if (response.status === 498) {
+    await userAPI.postRefresh();
+    return ky(request);
+  }
+  const data: ResponseData = await response?.json();
+  return new Response(JSON.stringify(data?.result ?? data?.message), {
+    status: response.status,
+  });
 };
 
 export { processResponse };


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 로그인 유지를 위해 API status 498인 경우 /refresh api 호출 후 기존 API 재호출 로직 추가

## 문제 상황과 해결

- accessToken, refreshToken이 cookie에 저장되어 있으며, httpOnly로 설정 되어 있기 때문에 클라이언트 사이드에서 제어 불가능함 
  이를 해결하기 위해 BE에서 API를 호출할때 status를 내려주도록 협의 

      Profile API
      1.로그인 했지만 accessToken이 만료된 유저 (498)
      2.로그인 했지만 refreshToken만료 & 로그인 하지 않은 유저 (204) 
      3.로그인 (200)
      
      Profile API 제외 모든 API
      1.로그인 했지만 accessToken이 만료된 유저 (498)
      2.로그인 (기존방식 그대로)

