### PR TITLE
fix : profile 498 에러시 무한루프도는 현상 수정

### DIFF
--- a/src/api/user/api.ts
+++ b/src/api/user/api.ts
@@ -4,7 +4,13 @@ import { request } from '@/utils/ky/request';
 class UserAPI {
   /** 로그인한 유저의 프로필을 조회합니다 */
   async getProfile() {
-    return request.get('v1/users/profile').json<Profile | undefined>();
+    return request
+      .get('v1/users/profile', {
+        retry: {
+          limit: 0,
+        },
+      })
+      .json<Profile | undefined>();
   }
 
   async postLogin({ email, password, keep }: { email: string; password: string; keep: string }) {

--- a/src/api/user/hooks/useProfile.ts
+++ b/src/api/user/hooks/useProfile.ts
@@ -1,8 +1,16 @@
-import { useSuspenseQuery } from '@suspensive/react-query';
+import { useQuery } from '@tanstack/react-query';
+
 import { Profile } from '@/api/types';
 import { userKeys } from '@/api/user/queryKeys';
 import { userAPI } from '../api';
 
-const useProfile = () => useSuspenseQuery<Profile | undefined>(userKeys.profile(), () => userAPI.getProfile());
-
+const useProfile = () => {
+  return useQuery<Profile | undefined>({
+    queryKey: userKeys.profile(),
+    queryFn: () => userAPI.getProfile(),
+    suspense: false,
+    cacheTime: 0,
+    retry: 0,
+  });
+};
 export default useProfile;

--- a/src/api/user/hooks/useProfile.ts
+++ b/src/api/user/hooks/useProfile.ts
@@ -8,6 +8,7 @@ const useProfile = () => {
   return useSuspenseQuery<Profile | undefined>({
     queryKey: userKeys.profile(),
     queryFn: () => userAPI.getProfile(),
+    retry: 1,
   });
 };
 export default useProfile;

--- a/src/api/user/hooks/useProfile.ts
+++ b/src/api/user/hooks/useProfile.ts
@@ -1,16 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@suspensive/react-query';
 
 import { Profile } from '@/api/types';
 import { userKeys } from '@/api/user/queryKeys';
 import { userAPI } from '../api';
 
 const useProfile = () => {
-  return useQuery<Profile | undefined>({
+  return useSuspenseQuery<Profile | undefined>({
     queryKey: userKeys.profile(),
     queryFn: () => userAPI.getProfile(),
-    suspense: false,
-    cacheTime: 0,
-    retry: 0,
   });
 };
 export default useProfile;

--- a/src/app/board/hooks/useBoardStates/useBoardStates.test.ts
+++ b/src/app/board/hooks/useBoardStates/useBoardStates.test.ts
@@ -1,9 +1,9 @@
 import { vi } from 'vitest';
 import { BoardDetail, Profile } from '@/api/types';
 import { renderHook } from '@/tests/test-utils';
-import { UseSuspenseQueryResultOnSuccess } from '@suspensive/react-query';
 import useRecruitStates from './useBoardStates';
 import * as apiHooksModule from '@/api/hooks';
+import { UseQueryResult } from '@tanstack/react-query';
 
 const 작성자_프로필 = {
   userId: 128,
@@ -63,7 +63,7 @@ describe('useRecruitStates 테스팅 1 - 작성자가 조회중인 경우', () =
     const spy = vi.spyOn(apiHooksModule, 'useProfile');
     spy.mockReturnValue({
       data: 작성자_프로필,
-    } as UseSuspenseQueryResultOnSuccess<Profile | undefined>);
+    } as UseQueryResult<Profile | undefined>);
   });
 
   test('모집중이고 인원이 꽉차지 않은 먹팟', () => {
@@ -138,7 +138,7 @@ describe('useRecruitStates 테스팅 2 - 작성자가 아닌 사람이 조회중
     const spy = vi.spyOn(apiHooksModule, 'useProfile');
     spy.mockReturnValue({
       data: 비작성자_프로필,
-    } as UseSuspenseQueryResultOnSuccess<Profile | undefined>);
+    } as UseQueryResult<Profile | undefined>);
   });
 
   test('모집중, 참여중, 나이 제한 없음, 인원이 꽉차지 않음', () => {

--- a/src/app/board/hooks/useBoardStates/useBoardStates.test.ts
+++ b/src/app/board/hooks/useBoardStates/useBoardStates.test.ts
@@ -3,7 +3,7 @@ import { BoardDetail, Profile } from '@/api/types';
 import { renderHook } from '@/tests/test-utils';
 import useRecruitStates from './useBoardStates';
 import * as apiHooksModule from '@/api/hooks';
-import { UseQueryResult } from '@tanstack/react-query';
+import { UseSuspenseQueryResultOnSuccess } from '@suspensive/react-query';
 
 const 작성자_프로필 = {
   userId: 128,
@@ -63,7 +63,7 @@ describe('useRecruitStates 테스팅 1 - 작성자가 조회중인 경우', () =
     const spy = vi.spyOn(apiHooksModule, 'useProfile');
     spy.mockReturnValue({
       data: 작성자_프로필,
-    } as UseQueryResult<Profile | undefined>);
+    } as UseSuspenseQueryResultOnSuccess<Profile | undefined>);
   });
 
   test('모집중이고 인원이 꽉차지 않은 먹팟', () => {
@@ -138,7 +138,7 @@ describe('useRecruitStates 테스팅 2 - 작성자가 아닌 사람이 조회중
     const spy = vi.spyOn(apiHooksModule, 'useProfile');
     spy.mockReturnValue({
       data: 비작성자_프로필,
-    } as UseQueryResult<Profile | undefined>);
+    } as UseSuspenseQueryResultOnSuccess<Profile | undefined>);
   });
 
   test('모집중, 참여중, 나이 제한 없음, 인원이 꽉차지 않음', () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,9 @@ export default function Home() {
         </Suspense>
         <BoardSection />
       </Content>
-      <FloatingButton />
+      <Suspense>
+        <FloatingButton />
+      </Suspense>
     </>
   );
 }

--- a/src/app/write/loading.tsx
+++ b/src/app/write/loading.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { useRef } from 'react';
+import { Loading } from '@/components';
+
+const WriteLoadingPage = () => {
+  const ref = useRef(null);
+  return (
+    <div ref={ref}>
+      <Loading ref={ref} />
+    </div>
+  );
+};
+
+export default WriteLoadingPage;

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import { FirstStep, SecondStep, WriteTitle } from '@/app/write/components';
-import { useFunnel } from '@/hooks';
+import { useFunnel, useLoginRedirect } from '@/hooks';
 import { useProfile } from '@/api/hooks';
 import useFormStore from '@/app/write/store/useFormStore';
 import { useLeaveModal } from '@/app/write/hooks';
@@ -12,11 +11,9 @@ import { wrapper } from './style.css';
 export default function Write() {
   const [step, { prevStep, nextStep }] = useFunnel(['1', '2']);
   const { reset, setData } = useFormStore();
-  const { data } = useProfile();
-  const router = useRouter();
-  if (!data) {
-    router.push('/login');
-  }
+  const { data: profile } = useProfile();
+
+  const { redirectToLogin } = useLoginRedirect();
 
   const preventClose = (e: BeforeUnloadEvent) => {
     e.preventDefault();
@@ -31,6 +28,12 @@ export default function Write() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!profile) {
+      redirectToLogin();
+    }
+  }, [redirectToLogin, profile]);
 
   useLeaveModal(true);
 

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -20,7 +20,7 @@ const Header = ({ actionRequired = true }: Props) => {
       <Logo />
       <div className={actions}>
         <FeedbackAction />
-        {actionRequired && <HeaderActions />}
+        <Suspense>{actionRequired && <HeaderActions />}</Suspense>
       </div>
     </HeaderWrapper>
   );

--- a/src/providers/ProfileProvider.tsx
+++ b/src/providers/ProfileProvider.tsx
@@ -5,7 +5,10 @@ import { api, queryKeys } from '@/api';
 
 const ProfileProvider = async ({ children }: { children: ReactNode }) => {
   const queryClient = getQueryClient();
-  await queryClient.prefetchQuery(queryKeys.user.profile(), () => api.user.getProfile());
+  await queryClient.prefetchQuery(queryKeys.user.profile(), () => api.user.getProfile(), {
+    retry: 1,
+  });
+
   const dehydratedState = dehydrate(queryClient);
 
   return <Hydrate state={dehydratedState}>{children}</Hydrate>;

--- a/src/utils/ky/hooks/processResponse.ts
+++ b/src/utils/ky/hooks/processResponse.ts
@@ -1,20 +1,25 @@
 import ky, { AfterResponseHook } from 'ky';
 import { ResponseData } from '@/types/data';
 import { userAPI } from '@/api/user/api';
+
+const getProcessedResponse = (response: ResponseData) => {
+  return new Response(JSON.stringify(response?.result ?? response?.message), {
+    status: response.status,
+  });
+};
+
 /** response 에서 필요한 데이터 추출 및 에러 전처리 */
 const processResponse: AfterResponseHook = async (request, options, response) => {
   if (response.status === 204) {
-    return new Response(undefined, { status: 204 });
+    return new Response(undefined, { status: response.status });
   } else if (response.status === 498) {
     await userAPI.postRefresh();
-    return ky(request);
-  } else if (response.status === 400) {
-    return new Response(undefined, { status: 400 });
+    const data: ResponseData = await ky(request).json();
+    return getProcessedResponse(data);
   }
+
   const data: ResponseData = await response?.json();
-  return new Response(JSON.stringify(data?.result ?? data?.message), {
-    status: response.status,
-  });
+  return getProcessedResponse(data);
 };
 
 export { processResponse };

--- a/src/utils/ky/hooks/processResponse.ts
+++ b/src/utils/ky/hooks/processResponse.ts
@@ -8,6 +8,8 @@ const processResponse: AfterResponseHook = async (request, options, response) =>
   } else if (response.status === 498) {
     await userAPI.postRefresh();
     return ky(request);
+  } else if (response.status === 400) {
+    return new Response(undefined, { status: 400 });
   }
   const data: ResponseData = await response?.json();
   return new Response(JSON.stringify(data?.result ?? data?.message), {

--- a/src/utils/ky/request.ts
+++ b/src/utils/ky/request.ts
@@ -13,6 +13,9 @@ const PREFIX_URL = (() => {
 
 export const request = ky.create({
   prefixUrl: PREFIX_URL,
+  retry: {
+    limit: 0,
+  },
   hooks: {
     beforeRequest: [setupCookies],
     beforeError: [processError],

--- a/src/utils/ky/request.ts
+++ b/src/utils/ky/request.ts
@@ -13,9 +13,6 @@ const PREFIX_URL = (() => {
 
 export const request = ky.create({
   prefixUrl: PREFIX_URL,
-  retry: {
-    limit: 0,
-  },
   hooks: {
     beforeRequest: [setupCookies],
     beforeError: [processError],


### PR DESCRIPTION
## 체크 리스트

- [x] 적절한 제목으로 수정했나요?
- [x] 관련된 이슈와 연결 시켰나요?
- [x] Target Branch를 올바르게 설정했나요?
- [x] Label을 알맞게 설정했나요?

## 작업 내역

- 로그인 무한루프 로직 수정 
- suspense 설정으로 인한 에러시 재요청이 일어나고 있음 -> useQuery로 변경 후 retry 0번으로 세팅 (Default:3) 

## 문제 상황과 해결
아래와 같은 내용으로 협의 완료
- BE에서 /refresh api에서 status: 400이 호출 되는 경우 refreshToken 삭제 요청 
- FE에서는 refreshToken만료시 profile(498) -> /refresh (400) -> profile (204) 순서로 호출 
